### PR TITLE
Make operator build script more flexible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+pull-secrets

--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@
 
 It's critical to correctly configure the credentials here or the building process will fail with permission errors.
 
+Also, this sets of scripts relying on podman as a container engine.
+For Mac users podman 3.3+ is required, see [podman machine](https://docs.podman.io/en/latest/markdown/podman-machine.1.html?highlight=machine).
+
 ### Accessing registry.ci.openshift.org
 
 For registry.ci.openshift.org, you first need to copy the token from https://oauth-openshift.apps.ci.l2s4.p1.openshiftapps.com/oauth/token/request (top left, "Display Token") and run this command:

--- a/README.md
+++ b/README.md
@@ -15,11 +15,21 @@ For registry.ci.openshift.org, you first need to copy the token from https://oau
 podman login -u <username> -p <token> https://registry.ci.openshift.org
 ```
 
+### Login into quay.io
+This set of scripts assumes that artifacts will be pushed into your personal quay.io registry,
+for not facing with auth issues need to log in into quay.io first.
+```sh
+podman login quay.io
+```
+
 ### Obtaining OpenShift's quay.io credentials
 
 For OpenShift's quay.io, the credentials need to be taken from https://cloud.redhat.com/openshift/create/local. Click `Download pull secret` and store `pull-secret.txt` in a safe location on your computer.
 
 **NOTE:** These are not your personal credentials, you won't be able to use them to access your personal quay.io account. These credentials are required to obtain the base release image only.
+
+### Limitations
+- podman has an issues with mounting volumes on mac platform, see [this issue](https://github.com/containers/podman/issues/8016) for more details.
 
 ## Build an operator image with your custom changes
 

--- a/build_all.sh
+++ b/build_all.sh
@@ -84,4 +84,4 @@ echo "Building a release image"
 ./build_release_image.sh -u "$USERNAME" -a "$OC_REGISTRY_AUTH_FILE" \
     --kcmo quay.io/"$USERNAME"/cluster-kube-controller-manager-operator:"$TAG" \
     --mco quay.io/"$USERNAME"/machine-config-operator:"$TAG" \
-    --cccmo quay.io/"$USERNAME"/cluster-kube-controller-manager-operator:"$TAG"
+    --cccmo quay.io/"$USERNAME"/cluster-cloud-controller-manager-operator:"$TAG"

--- a/build_operator_image.sh
+++ b/build_operator_image.sh
@@ -8,8 +8,11 @@ help() {
     echo "Usage: ./build_operator_image.sh [options]"
     echo "Options:"
     echo "-h, --help        show this message"
+    echo "-a, --auth        path of OCP CI registry auth file, default: pull-secrets/pull-secrets.json"
     echo "-o, --operator    operator name to build, examples: machine-config-operator, cluster-kube-controller-manager-operator"
     echo "-i, --id          id of your pull request to apply on top of the master branch"
+    echo "-r, --repo-url    repository url for clone"
+    echo "-c, --commit      commit hash for clone, repository-url should be provided"
     echo "-u, --username    registered username in quay.io"
     echo "-t, --tag         push to a custom tag in your origin release image repo, default: latest"
     echo "-d, --dockerfile  non-default Dockerfile name, default: Dockerfile"
@@ -18,6 +21,7 @@ help() {
 
 TAG="latest"
 DOCKERFILE="Dockerfile"
+: ${OC_REGISTRY_AUTH_FILE:=$(pwd)"/pull-secrets/pull-secrets.json"}
 
 # Parse Options
 while [[ $# -gt 0 ]]; do
@@ -25,6 +29,11 @@ while [[ $# -gt 0 ]]; do
         -h|--help)
             help
             exit 0
+            ;;
+
+        -a|--auth)
+            OC_REGISTRY_AUTH_FILE=$2
+            shift 2
             ;;
 
         -u|--username)
@@ -44,6 +53,16 @@ while [[ $# -gt 0 ]]; do
 
         -i|--id)
             PRID=$2
+            shift 2
+            ;;
+
+        -r|--repo-url)
+            CUSTOM_REPO=$2
+            shift 2
+            ;;
+
+        -c|--commit)
+            COMMIT_HASH=$2
             shift 2
             ;;
 
@@ -70,8 +89,20 @@ if [ -z "$OPERATOR_NAME" ]; then
     exit 1
 fi
 
+if [ -n "$PRID" ] && [ -n "$COMMIT_HASH" ]; then
+    echo "-c (commit hash) and -i (pr id) options can not be used simultaneously"
+    exit 1
+fi
+
 OPERATOR_IMAGE=quay.io/$USERNAME/$OPERATOR_NAME:$TAG
-GITHUB_REPO="https://github.com/openshift/$OPERATOR_NAME"
+
+
+if [ -n "$CUSTOM_REPO" ]; then
+    GITHUB_REPO="$CUSTOM_REPO"
+else
+    GITHUB_REPO="https://github.com/openshift/$OPERATOR_NAME"
+fi
+
 
 git ls-remote $GITHUB_REPO 1>/dev/null
 
@@ -81,15 +112,23 @@ git clone $GITHUB_REPO
 
 pushd $OPERATOR_NAME
 
-echo "Applying your changes"
-git fetch origin pull/$PRID/head:changes
-git checkout changes
-git rebase master
+if [ -n "$PRID" ]; then
+  echo "Applying your changes"
+  git fetch origin pull/$PRID/head:$PRID
+  git checkout $PRID
+  git rebase master
+fi
+
+if [ -n "$COMMIT_HASH" ]; then
+  echo "Checkoid commit $COMMIT_HASH"
+  git checkout $COMMIT_HASH
+fi
 
 echo "Setting operator image to $OPERATOR_IMAGE"
 
 echo "Start building operator image"
-podman build --no-cache -t $OPERATOR_IMAGE -f $DOCKERFILE .
+# authfile is podman specific option ¯\_(ツ)_/¯. Consider to drop docker for the great good.
+podman build --no-cache -t $OPERATOR_IMAGE -f $DOCKERFILE . --authfile="$( realpath "${OC_REGISTRY_AUTH_FILE}")"
 
 echo "Pushing operator image to quay.io"
 podman push $OPERATOR_IMAGE

--- a/build_release_image.sh
+++ b/build_release_image.sh
@@ -12,6 +12,7 @@ help() {
     echo "-t, --tag       push to a custom tag in your origin release image repo, default: latest"
     echo "-r, --release   openshift release version, default: 4.9"
     echo "-a, --auth      path of registry auth file, default: ./pull-secret.txt"
+    echo "--release-image release image url, default is latest nightly of given release"
     echo "--cccmo         custom cluster-cloud-controller-manager-operator image name, default: quay.io/openshift/origin-cluster-cloud-controller-manager-operator:$RELEASE"
     echo "--aws-ccm       custom aws cloud-controller-manager image name, default: quay.io/openshift/origin-aws-cloud-controller-manager:$RELEASE"
     echo "--azure-ccm     custom azure cloud-controller-manager image name, default: quay.io/openshift/origin-azure-cloud-controller-manager:$RELEASE"
@@ -24,7 +25,7 @@ help() {
 : ${GOPATH:=${HOME}/go}
 : ${TAG:="latest"}
 : ${RELEASE:="4.9"}
-: ${OC_REGISTRY_AUTH_FILE:="pull-secret.txt"}
+: ${OC_REGISTRY_AUTH_FILE:=$(pwd)"/pull-secrets/pull-secrets.json"}
 : ${CCCMO_IMAGE:="quay.io/openshift/origin-cluster-cloud-controller-manager-operator:$RELEASE"}
 : ${AWSCCM_IMAGE:="quay.io/openshift/origin-aws-cloud-controller-manager:$RELEASE"}
 : ${AZURECCM_IMAGE:="quay.io/openshift/origin-azure-cloud-controller-manager:$RELEASE"}
@@ -55,6 +56,11 @@ while [[ $# -gt 0 ]]; do
 
         -a|--auth)
             OC_REGISTRY_AUTH_FILE=$2
+            shift 2
+            ;;
+
+        --release-image)
+            FROM_IMAGE=$2
             shift 2
             ;;
 
@@ -112,14 +118,17 @@ if [ ! -f "$OC_REGISTRY_AUTH_FILE" ]; then
 fi
 
 echo "Creating local image registry at localhost:5000"
-docker rm -fi registry
-docker run -d -p 5000:5000 --restart=always --name registry docker.io/library/registry:2
+podman rm -fi registry
+podman run -d -p 5000:5000 --restart=always --name registry docker.io/library/registry:2
 
 PREFIX="Pull From: "
 DEST_IMAGE="quay.io/$USERNAME/origin-release:$TAG"
 TEMP_IMAGE="localhost:5000/origin-release:$TAG"
-FROM_IMAGE=$(curl -s  https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp-dev-preview/latest-$RELEASE/release.txt | grep "$PREFIX" | sed -e "s/^$PREFIX//")
 
+if [ ! -f "$FROM_IMAGE" ]; then
+    FROM_IMAGE=$(curl -s  https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp-dev-preview/latest-$RELEASE/release.txt | grep "$PREFIX" | sed -e "s/^$PREFIX//")
+fi
+echo "Release image: $FROM_IMAGE"
 echo "Start building local release image"
 
 oc adm release new \
@@ -139,18 +148,18 @@ oc adm release new \
 
 echo "The image has been created as $TEMP_IMAGE"
 
-docker pull $TEMP_IMAGE --tls-verify=false
+podman pull $TEMP_IMAGE --tls-verify=false
 
-docker image tag $TEMP_IMAGE $DEST_IMAGE
+podman image tag $TEMP_IMAGE $DEST_IMAGE
 
-docker push $DEST_IMAGE
+podman push $DEST_IMAGE
 
 echo "Successfully pushed $DEST_IMAGE"
 
 echo "Destroying the local registry"
-docker rm -fi registry
+podman rm -fi registry
 
 echo "Testing release image"
-docker pull $DEST_IMAGE
+podman pull $DEST_IMAGE
 echo "$DEST_IMAGE image was tested, you can now deploy with the following command:"
 echo "OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE=$DEST_IMAGE openshift-install create cluster (...)"


### PR DESCRIPTION
- added possibility to build images from
specific repository and commit, not only
from prs into openshift repo

Also contains bunch of another changes
- docker replaced to podman everywhere
- default pull-secret location changed
- added --release-image flag for specifying
  release image more precisely